### PR TITLE
session scope is not enabled #6

### DIFF
--- a/sentry.cfc
+++ b/sentry.cfc
@@ -351,7 +351,7 @@ component displayname="sentry" output="false" accessors="true"{
 		// HTTP interface
 		// https://docs.sentry.io/clientdev/interfaces/http/
 		arguments.captureStruct["sentry.interfaces.Http"] = {
-			"sessions" 		: session,
+			"sessions" 		: (isDefined('session'))?session:{},
 			"url" 			: arguments.path,
 			"method" 		: arguments.cgiVars.request_method,
 			"data" 			: form,

--- a/sentry.cfc
+++ b/sentry.cfc
@@ -351,7 +351,7 @@ component displayname="sentry" output="false" accessors="true"{
 		// HTTP interface
 		// https://docs.sentry.io/clientdev/interfaces/http/
 		arguments.captureStruct["sentry.interfaces.Http"] = {
-			"sessions" 		: (isDefined('session'))?session:{},
+			"sessions" 		: isDefined('session') ? session : {},
 			"url" 			: arguments.path,
 			"method" 		: arguments.cgiVars.request_method,
 			"data" 			: form,


### PR DESCRIPTION
The capture() function now checks if the session scope exists before using it.